### PR TITLE
refactor: move inline styles to CSS classes

### DIFF
--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -4,12 +4,9 @@ const year = new Date().getFullYear();
 ---
 
 <footer class="foot">
-  <div
-    class="shell"
-    style="display: flex; justify-content: space-between; width: 100%; flex-wrap: wrap; gap: 16px;"
-  >
+  <div class="shell">
     <span>&copy; {year} {META.author} &middot; Partin Thoughts</span>
-    <span style="display: flex; gap: 18px;">
+    <span class="foot-links">
       <a href="/rss.xml">RSS</a>
       <a href="#">Colophon</a>
       <a href="#">Email</a>

--- a/src/components/Masthead.astro
+++ b/src/components/Masthead.astro
@@ -46,6 +46,7 @@ const { activeNav = "" } = Astro.props;
           >
             <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"></path>
           </svg>
+          <!-- Inline style required: ThemeToggle.astro toggles style.display via JS -->
           <svg
             class="icon-sun"
             viewBox="0 0 24 24"

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -58,7 +58,7 @@ const dateLabel = date.toLocaleDateString("en-US", {
                 <div />
               )}
               {next ? (
-                <a href={`/p/${next.id}/`} style="text-align: right;">
+                <a href={`/p/${next.id}/`} class="article-next--newer">
                   <div class="lbl">Newer &rarr;</div>
                   <div class="ttl">{next.title}</div>
                 </a>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -407,6 +407,16 @@ kbd {
   gap: 16px;
   flex-wrap: wrap;
 }
+.foot .shell {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+.foot-links {
+  display: flex;
+  gap: 18px;
+}
 .foot a {
   transition: color 180ms var(--ease);
 }
@@ -569,6 +579,9 @@ kbd {
 .article-next a:hover {
   border-color: var(--ink-soft);
   transform: translateY(-2px);
+}
+.article-next--newer {
+  text-align: right;
 }
 .article-next .lbl {
   font-family: var(--mono);


### PR DESCRIPTION
## Summary

- Move footer inline styles to `.foot .shell` and `.foot-links` CSS classes
- Move post next-link `text-align: right` to `.article-next--newer` CSS class
- Add comment explaining the remaining inline `display:none` on the theme toggle icon (toggled by JS)

## Test plan

- [x] Verify footer layout (left/right alignment) on any page
- [x] Verify "Newer" post link is right-aligned on article pages
- [x] Verify theme toggle still works (sun/moon icon swap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)