### PR TITLE
fix: polish command palette kbd styles and platform shortcut

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -12,6 +12,8 @@ interface Props {
   items: PaletteItem[];
 }
 
+const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.userAgent);
+
 export default function CommandPalette({ items }: Props) {
   const [open, setOpen] = useState(false);
   const [q, setQ] = useState("");
@@ -49,7 +51,6 @@ export default function CommandPalette({ items }: Props) {
   // Global keyboard shortcuts
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      const isMac = /Mac|iPhone|iPad/.test(navigator.userAgent);
       const mod = isMac ? e.metaKey : e.ctrlKey;
       if (mod && e.key.toLowerCase() === "k") {
         e.preventDefault();
@@ -104,7 +105,7 @@ export default function CommandPalette({ items }: Props) {
       <div className="palette-backdrop" onClick={() => setOpen(false)} />
       <div className="palette-panel" role="dialog" aria-label="Search">
         <div className="palette-input-wrap">
-          <span className="palette-kbd">&#8984;K</span>
+          <span className="palette-kbd">{isMac ? "\u2318K" : "Ctrl+K"}</span>
           <input
             ref={inputRef}
             placeholder="Search essays, tags, pages…"

--- a/src/components/Masthead.astro
+++ b/src/components/Masthead.astro
@@ -32,7 +32,7 @@ const { activeNav = "" } = Astro.props;
             <circle cx="11" cy="11" r="7"></circle><path d="m20 20-3.5-3.5"></path>
           </svg>
           <span>Search</span>
-          <kbd>&#8984;K</kbd>
+          <kbd data-shortcut-label>&#8984;K</kbd>
         </button>
         <button class="iconbtn" data-theme-toggle aria-label="Toggle theme">
           <svg
@@ -66,3 +66,11 @@ const { activeNav = "" } = Astro.props;
     </div>
   </div>
 </header>
+
+<script>
+  if (!/Mac|iPhone|iPad/.test(navigator.userAgent)) {
+    document.querySelectorAll("[data-shortcut-label]").forEach((el) => {
+      el.textContent = "Ctrl+K";
+    });
+  }
+</script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -198,12 +198,14 @@ kbd {
   display: inline-flex;
   align-items: center;
   gap: 8px;
-  font-size: 12px;
+  font-size: 13px;
   color: var(--ink-mute);
   padding: 6px 10px 6px 8px;
   border: 1px solid var(--line);
   border-radius: 7px;
   background: transparent;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
   transition:
     border-color 180ms var(--ease),
     color 180ms var(--ease);
@@ -217,7 +219,7 @@ kbd {
   height: 13px;
 }
 .searchbtn kbd {
-  font-size: 10px;
+  font-size: 11px;
   padding: 1px 5px;
 }
 
@@ -858,10 +860,11 @@ kbd {
 .palette-kbd {
   font-family: var(--mono);
   font-size: 11px;
-  color: var(--ink-mute);
+  color: var(--ink-soft);
   border: 1px solid var(--line);
   padding: 2px 6px;
   border-radius: 4px;
+  background: var(--bg-elev);
 }
 #palette-input {
   flex: 1;
@@ -879,10 +882,11 @@ kbd {
 .palette-close {
   font-family: var(--mono);
   font-size: 10px;
-  color: var(--ink-mute);
+  color: var(--ink-soft);
   border: 1px solid var(--line);
   padding: 2px 6px;
   border-radius: 4px;
+  background: var(--bg-elev);
 }
 .palette-results {
   list-style: none;


### PR DESCRIPTION
## Summary
- Add consistent `background` and `color` to `.palette-kbd` and `.palette-close` to match global `kbd` styling
- Bump search button font sizes (12px→13px, 10px→11px) and add font smoothing for crisper rendering
- Show `Ctrl+K` on Windows/Linux instead of `⌘K` in both the masthead button and command palette

## Test plan
- [x] Lint, format, type check, and build all pass
- [x] Verify kbd elements in command palette look consistent (top and bottom)
- [x] Verify `⌘K` displays on Mac, `Ctrl+K` on Windows/Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)