### PR TITLE
feat: add RSS feed and use META constants in Base layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: npm
 
       - run: npm ci

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,5 +3,6 @@ import { defineConfig } from "astro/config";
 import react from "@astrojs/react";
 
 export default defineConfig({
+  site: "https://thoughts.partin.io",
   integrations: [react()],
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@astrojs/check": "^0.9.8",
         "@astrojs/react": "^5.0.3",
+        "@astrojs/rss": "^4.0.18",
         "astro": "^6.1.8",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -202,6 +203,17 @@
         "@types/react-dom": "^17.0.17 || ^18.0.6 || ^19.0.0",
         "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
         "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.18.tgz",
+      "integrity": "sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.7",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@astrojs/telemetry": {
@@ -2035,6 +2047,18 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4700,6 +4724,42 @@
         "fast-string-width": "^1.1.0"
       }
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -6828,6 +6888,21 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -7607,6 +7682,18 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/suf-log": {
       "version": "2.5.3",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "dependencies": {
     "@astrojs/check": "^0.9.8",
     "@astrojs/react": "^5.0.3",
+    "@astrojs/rss": "^4.0.18",
     "astro": "^6.1.8",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -5,6 +5,7 @@ import Footer from "../components/Footer.astro";
 import CommandPaletteIsland from "../components/CommandPaletteIsland.astro";
 import HoverPreview from "../components/HoverPreview.astro";
 import ThemeToggle from "../components/ThemeToggle.astro";
+import { META } from "../types";
 
 interface Props {
   title?: string;
@@ -12,13 +13,9 @@ interface Props {
   activeNav?: string;
 }
 
-const {
-  title = "Partin Thoughts",
-  description = "Personal essays, borrowed wisdom, and observations from the ordinary.",
-  activeNav = "",
-} = Astro.props;
+const { title = META.name, description = META.bio, activeNav = "" } = Astro.props;
 
-const fullTitle = title === "Partin Thoughts" ? title : `${title} — Partin Thoughts`;
+const fullTitle = title === META.name ? title : `${title} — ${META.name}`;
 ---
 
 <!doctype html>

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -14,7 +14,7 @@ interface Props {
 
 const {
   title = "Partin Thoughts",
-  description = "Personal essays, working notes, and stray observations by E. Partin.",
+  description = "Personal essays, borrowed wisdom, and observations from the ordinary.",
   activeNav = "",
 } = Astro.props;
 
@@ -30,6 +30,7 @@ const fullTitle = title === "Partin Thoughts" ? title : `${title} — Partin Tho
     <meta name="description" content={description} />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="alternate" type="application/rss+xml" title="Partin Thoughts" href="/rss.xml" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,22 @@
+import rss from "@astrojs/rss";
+import { getCollection } from "astro:content";
+import type { APIContext } from "astro";
+import { META } from "../types";
+
+export async function GET(context: APIContext) {
+  const posts = (await getCollection("posts")).sort(
+    (a, b) => b.data.date.getTime() - a.data.date.getTime(),
+  );
+
+  return rss({
+    title: META.name,
+    description: META.bio,
+    site: context.site!,
+    items: posts.map((post) => ({
+      title: post.data.title,
+      pubDate: post.data.date,
+      description: post.data.excerpt,
+      link: `/p/${post.id}/`,
+    })),
+  });
+}


### PR DESCRIPTION
## Summary
- Add `@astrojs/rss` with a `/rss.xml` endpoint that auto-includes all posts sorted by date
- Add RSS autodiscovery `<link>` in `<head>` and set `site` in Astro config for absolute feed URLs
- Refactor Base layout to use `META.name` and `META.bio` instead of hardcoded strings
- Bump CI workflow to Node 24

## Test plan
- [x] Verify `/rss.xml` renders with all posts and correct absolute URLs
- [x] Confirm RSS `<link rel="alternate">` is present in page source
- [x] Check site title and meta description still render correctly on all pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)