### PR TITLE
feat: add colophon page and update footer links

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,9 @@ This is an Astro 6 static blog with React islands. It builds to pure static HTML
 
 **Content system:** Posts are Markdown files in `src/content/posts/` with typed frontmatter (title, date, tag, excerpt). The schema is defined in `src/content.config.ts` using Zod. Tags are constrained to "work", "living", "personal". Adding a post means creating a `.md` file — no other files need updating.
 
-**Layout hierarchy:** `Base.astro` wraps every page (head, fonts, masthead, footer, global components). `Post.astro` extends Base for article pages, adding reading progress and prev/next navigation.
+**Layout hierarchy:** `Base.astro` wraps every page (head, fonts, masthead, footer, global components). It pulls default title and description from `META.name` and `META.bio` in `src/types.ts`. `Post.astro` extends Base for article pages, adding reading progress and prev/next navigation.
+
+**RSS feed:** `src/pages/rss.xml.ts` generates an RSS feed at `/rss.xml` using `@astrojs/rss`. It includes all posts sorted by date. The `site` property in `astro.config.mjs` is required for absolute URLs in the feed.
 
 **Interactivity model:** Almost everything ships zero client JS. Interactive features use two approaches:
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,16 @@ Your content here.
 
 No other files need updating.
 
+## Pages
+
+- `/` — homepage with featured post and recent feed
+- `/p/<slug>/` — individual post
+- `/archive/` — all posts
+- `/tags/` — browse by tag
+- `/about/` — about the author
+- `/colophon/` — how the site is built
+- `/rss.xml` — RSS feed
+
 ## Tech stack
 
 - **Astro 6** — static site generation

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -7,8 +7,13 @@ const year = new Date().getFullYear();
   <div class="shell">
     <span>&copy; {year} {META.author} &middot; Partin Thoughts</span>
     <span class="foot-links">
-      <a href="/rss.xml">RSS</a>
-      <a href="#">Colophon</a>
+      <a href="/rss.xml" target="_blank" rel="noopener noreferrer">RSS</a>
+      <a href="/colophon/">Colophon</a>
+      <a
+        href="https://github.com/espartin21/PartinThoughts"
+        target="_blank"
+        rel="noopener noreferrer">GitHub</a
+      >
       <a href="#">Email</a>
     </span>
   </div>

--- a/src/pages/colophon.astro
+++ b/src/pages/colophon.astro
@@ -1,0 +1,56 @@
+---
+import Base from "../layouts/Base.astro";
+---
+
+<Base title="Colophon">
+  <main class="page">
+    <section class="about">
+      <div class="shell shell--narrow">
+        <h1>How this site is built.</h1>
+        <div class="prose">
+          <p>
+            This site is built with <a
+              href="https://astro.build"
+              target="_blank"
+              rel="noopener noreferrer">Astro</a
+            >, a static site generator that ships pure HTML with zero client JavaScript by default.
+            Where interactivity is needed, small React components hydrate on the client &mdash; an
+            approach Astro calls islands.
+          </p>
+          <p>
+            Typography is set in <a
+              href="https://rsms.me/inter/"
+              target="_blank"
+              rel="noopener noreferrer">Inter Tight</a
+            > for body and display text, with <a
+              href="https://www.jetbrains.com/lp/mono/"
+              target="_blank"
+              rel="noopener noreferrer">JetBrains Mono</a
+            > for code and interface labels. Both are served via Google Fonts.
+          </p>
+          <p>
+            Colors use the OKLCH color space for perceptual uniformity across light and dark themes.
+            Theme preference is saved to <code>localStorage</code> and applied before first paint to avoid
+            flash.
+          </p>
+          <p>
+            Posts are Markdown files with typed frontmatter validated by Zod at build time. The site
+            compiles to static HTML &mdash; no server, no database, no runtime.
+          </p>
+          <p>
+            Code quality is maintained with TypeScript, ESLint, and Prettier. Commits follow
+            conventional commit format, enforced by Husky and commitlint.
+          </p>
+          <p>
+            The source is public. Found a bug or have a suggestion?
+            <a
+              href="https://github.com/espartin21/PartinThoughts/issues"
+              target="_blank"
+              rel="noopener noreferrer">Open an issue</a
+            >.
+          </p>
+        </div>
+      </div>
+    </section>
+  </main>
+</Base>


### PR DESCRIPTION
## Summary
- Add `/colophon` page describing the site's tech stack, typography, color system, and build tools
- Update footer with GitHub repo link, RSS and external links open in new tabs
- Document RSS feed and site pages in CLAUDE.md and README

## Test plan
- [x] Verify `/colophon/` renders correctly in light and dark mode
- [x] Confirm all external links (Astro, Inter Tight, JetBrains Mono, GitHub issues) open in new tabs
- [x] Check footer links: RSS (new tab), Colophon (navigates), GitHub (new tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)