### PR TITLE
feat: enhance command palette with theme toggle and close animation

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -39,6 +39,8 @@ export default function CommandPalette({ items }: Props) {
 
   const closePalette = useCallback(() => {
     setClosing(true);
+    setQ("");
+    setIdx(0);
     setTimeout(() => {
       setOpen(false);
       setClosing(false);

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -6,6 +6,7 @@ interface PaletteItem {
   href: string;
   excerpt: string;
   hay?: string;
+  action?: () => void;
 }
 
 interface Props {
@@ -14,19 +15,60 @@ interface Props {
 
 const isMac = typeof navigator !== "undefined" && /Mac|iPhone|iPad/.test(navigator.userAgent);
 
+function toggleTheme() {
+  const current = document.documentElement.getAttribute("data-theme");
+  const next = current === "dark" ? "light" : "dark";
+  document.documentElement.setAttribute("data-theme", next);
+  localStorage.setItem("pt-theme", next);
+  // Update the toggle button icons
+  const btn = document.querySelector("[data-theme-toggle]");
+  if (btn) {
+    const moon = btn.querySelector(".icon-moon") as HTMLElement;
+    const sun = btn.querySelector(".icon-sun") as HTMLElement;
+    if (moon) moon.style.display = next === "dark" ? "none" : "";
+    if (sun) sun.style.display = next === "dark" ? "" : "none";
+  }
+}
+
 export default function CommandPalette({ items }: Props) {
   const [open, setOpen] = useState(false);
+  const [closing, setClosing] = useState(false);
   const [q, setQ] = useState("");
   const [idx, setIdx] = useState(0);
   const inputRef = useRef<HTMLInputElement>(null);
 
+  const closePalette = useCallback(() => {
+    setClosing(true);
+    setTimeout(() => {
+      setOpen(false);
+      setClosing(false);
+    }, 200);
+  }, []);
+
+  const allItems = useMemo(() => {
+    const themeItem: PaletteItem = {
+      kind: "action",
+      title: "Toggle theme",
+      href: "",
+      excerpt: "Switch between light and dark mode",
+      hay: "theme dark light mode toggle",
+      action: toggleTheme,
+    };
+    return [...items, themeItem];
+  }, [items]);
+
   const filtered = useMemo(() => {
     const query = q.trim().toLowerCase();
-    if (!query) return items.slice(0, 9);
-    return items
+    if (!query) {
+      const pages = allItems.filter((it) => it.kind === "page");
+      const posts = allItems.filter((it) => it.kind === "essay").slice(0, 4);
+      const actions = allItems.filter((it) => it.kind === "action");
+      return [...pages, ...posts, ...actions];
+    }
+    return allItems
       .filter((it) => it.title.toLowerCase().includes(query) || (it.hay && it.hay.includes(query)))
       .slice(0, 12);
-  }, [q, items]);
+  }, [q, allItems]);
 
   const openPalette = useCallback(() => {
     setOpen(true);
@@ -54,7 +96,8 @@ export default function CommandPalette({ items }: Props) {
       const mod = isMac ? e.metaKey : e.ctrlKey;
       if (mod && e.key.toLowerCase() === "k") {
         e.preventDefault();
-        setOpen((o) => !o);
+        if (open) closePalette();
+        else setOpen(true);
         return;
       }
       if (!open) {
@@ -68,7 +111,7 @@ export default function CommandPalette({ items }: Props) {
         return;
       }
       if (e.key === "Escape") {
-        setOpen(false);
+        closePalette();
         return;
       }
       if (e.key === "ArrowDown") {
@@ -83,14 +126,15 @@ export default function CommandPalette({ items }: Props) {
         e.preventDefault();
         const it = filtered[idx];
         if (it) {
-          setOpen(false);
-          window.location.href = it.href;
+          closePalette();
+          if (it.action) it.action();
+          else window.location.href = it.href;
         }
       }
     }
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [open, filtered, idx, openPalette]);
+  }, [open, filtered, idx, openPalette, closePalette]);
 
   if (!open) return null;
 
@@ -102,8 +146,12 @@ export default function CommandPalette({ items }: Props) {
         zIndex: 70,
       }}
     >
-      <div className="palette-backdrop" onClick={() => setOpen(false)} />
-      <div className="palette-panel" role="dialog" aria-label="Search">
+      <div className={`palette-backdrop${closing ? " closing" : ""}`} onClick={closePalette} />
+      <div
+        className={`palette-panel${closing ? " closing" : ""}`}
+        role="dialog"
+        aria-label="Search"
+      >
         <div className="palette-input-wrap">
           <span className="palette-kbd">{isMac ? "\u2318K" : "Ctrl+K"}</span>
           <input
@@ -126,7 +174,7 @@ export default function CommandPalette({ items }: Props) {
               letterSpacing: "-0.01em",
             }}
           />
-          <button className="palette-close" onClick={() => setOpen(false)} aria-label="Close">
+          <button className="palette-close" onClick={closePalette} aria-label="Close">
             esc
           </button>
         </div>
@@ -139,8 +187,9 @@ export default function CommandPalette({ items }: Props) {
                 key={it.href}
                 aria-selected={i === idx}
                 onClick={() => {
-                  setOpen(false);
-                  window.location.href = it.href;
+                  closePalette();
+                  if (it.action) it.action();
+                  else window.location.href = it.href;
                 }}
               >
                 <span className="kind">{it.kind}</span>

--- a/src/components/CommandPaletteIsland.astro
+++ b/src/components/CommandPaletteIsland.astro
@@ -11,6 +11,7 @@ const items = [
   { kind: "page", title: "Archive", href: "/archive/", excerpt: "All posts by year" },
   { kind: "page", title: "Tags", href: "/tags/", excerpt: "Filter by topic" },
   { kind: "page", title: "About", href: "/about/", excerpt: "Who writes this" },
+  { kind: "page", title: "Colophon", href: "/colophon/", excerpt: "How this site is built" },
   ...sortedPosts.map((p) => ({
     kind: "essay",
     title: p.data.title,

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -834,6 +834,9 @@ kbd {
   -webkit-backdrop-filter: blur(4px);
   animation: fadeIn 200ms var(--ease);
 }
+.palette-backdrop.closing {
+  animation: fadeOut 200ms var(--ease) forwards;
+}
 [data-theme="dark"] .palette-backdrop {
   background: oklch(0 0 0 / 0.55);
 }
@@ -849,6 +852,9 @@ kbd {
   box-shadow: 0 32px 80px -20px oklch(0 0 0 / 0.35);
   overflow: hidden;
   animation: palettePop 240ms var(--ease);
+}
+.palette-panel.closing {
+  animation: paletteDrop 200ms var(--ease) forwards;
 }
 .palette-input-wrap {
   display: flex;
@@ -989,6 +995,24 @@ kbd {
   to {
     opacity: 1;
     transform: translateX(-50%) translateY(0) scale(1);
+  }
+}
+@keyframes fadeOut {
+  from {
+    opacity: 1;
+  }
+  to {
+    opacity: 0;
+  }
+}
+@keyframes paletteDrop {
+  from {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+  to {
+    opacity: 0;
+    transform: translateX(-50%) translateY(-8px) scale(0.98);
   }
 }
 @keyframes underline {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -931,10 +931,10 @@ kbd {
   white-space: nowrap;
 }
 .palette-results li[aria-selected="true"] {
-  background: var(--bg-elev);
+  background: var(--line-soft);
 }
 .palette-results li:hover {
-  background: var(--bg-elev);
+  background: var(--line-soft);
 }
 .palette-results li .title {
   flex: 1;


### PR DESCRIPTION
## Summary
- Add "Toggle theme" action to the command palette (searchable via "theme", "dark", "light", "mode")
- Add Colophon page entry and curate default view: 5 pages + 4 recent posts + theme toggle
- Add matching fade-out/slide close animation (200ms) to balance the existing open animation
- Improve hover/selected contrast in both light and dark mode (use `--line-soft` over `--bg-elev`)
- Clear search query and selection when closing the palette

## Test plan
- [x] Cmd+K opens palette, type "theme" — toggle action appears and switches theme on select
- [x] Default view shows 10 items: Home, Archive, Tags, About, Colophon, 4 posts, Toggle theme
- [x] Esc / backdrop click / Cmd+K closes with smooth fade-out animation
- [x] Theme toggle syncs the masthead icon state
- [x] Selected/hovered row has visible contrast in both light and dark mode
- [x] Closing and reopening the palette shows a clean default view (no stale query)

🤖 Generated with [Claude Code](https://claude.com/claude-code)