### PR TITLE
chore: enforce curly braces on all if/else statements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,10 @@ npx astro check      # TypeScript type checking
 
 **Pre-commit hooks (husky):** ESLint, Prettier check, and `astro check` run automatically. Commit messages must follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `chore:`, etc.) — enforced by commitlint.
 
+## Code style
+
+**Curly braces:** All `if`/`else` statements must use curly braces, even for single-line bodies. Enforced by the `curly: ["error", "all"]` ESLint rule. Write `if (x) { return; }` not `if (x) return;`.
+
 ## Architecture
 
 This is an Astro 6 static blog with React islands. It builds to pure static HTML — no server runtime.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -24,6 +24,7 @@ export default [
       ...tseslint.configs.recommended.rules,
       ...reactHooks.configs.recommended.rules,
       "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
+      curly: ["error", "all"],
     },
   },
 

--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -25,8 +25,12 @@ function toggleTheme() {
   if (btn) {
     const moon = btn.querySelector(".icon-moon") as HTMLElement;
     const sun = btn.querySelector(".icon-sun") as HTMLElement;
-    if (moon) moon.style.display = next === "dark" ? "none" : "";
-    if (sun) sun.style.display = next === "dark" ? "" : "none";
+    if (moon) {
+      moon.style.display = next === "dark" ? "none" : "";
+    }
+    if (sun) {
+      sun.style.display = next === "dark" ? "" : "none";
+    }
   }
 }
 
@@ -98,8 +102,11 @@ export default function CommandPalette({ items }: Props) {
       const mod = isMac ? e.metaKey : e.ctrlKey;
       if (mod && e.key.toLowerCase() === "k") {
         e.preventDefault();
-        if (open) closePalette();
-        else setOpen(true);
+        if (open) {
+          closePalette();
+        } else {
+          setOpen(true);
+        }
         return;
       }
       if (!open) {
@@ -129,8 +136,11 @@ export default function CommandPalette({ items }: Props) {
         const it = filtered[idx];
         if (it) {
           closePalette();
-          if (it.action) it.action();
-          else window.location.href = it.href;
+          if (it.action) {
+            it.action();
+          } else {
+            window.location.href = it.href;
+          }
         }
       }
     }
@@ -138,7 +148,9 @@ export default function CommandPalette({ items }: Props) {
     return () => window.removeEventListener("keydown", onKey);
   }, [open, filtered, idx, openPalette, closePalette]);
 
-  if (!open) return null;
+  if (!open) {
+    return null;
+  }
 
   return (
     <div
@@ -190,8 +202,11 @@ export default function CommandPalette({ items }: Props) {
                 aria-selected={i === idx}
                 onClick={() => {
                   closePalette();
-                  if (it.action) it.action();
-                  else window.location.href = it.href;
+                  if (it.action) {
+                    it.action();
+                  } else {
+                    window.location.href = it.href;
+                  }
                 }}
               >
                 <span className="kind">{it.kind}</span>

--- a/src/components/HoverPreview.astro
+++ b/src/components/HoverPreview.astro
@@ -18,18 +18,24 @@ const previewData = posts
   }));
 ---
 
-<script define:vars={{ previewData }}>
+<script is:inline define:vars={{ previewData }}>
   function initHoverPreview() {
     const el = document.getElementById("preview");
-    if (!el) return;
+    if (!el) {
+      return;
+    }
     let hideT;
 
     function handleEnter(e) {
       const t = e.target.closest("[data-preview-slug]");
-      if (!t) return;
+      if (!t) {
+        return;
+      }
       const slug = t.getAttribute("data-preview-slug");
       const post = previewData.find((p) => p.slug === slug);
-      if (!post) return;
+      if (!post) {
+        return;
+      }
       clearTimeout(hideT);
       el.innerHTML = `
         <div class="pv-meta">${post.dateLabel} · ${post.tag} · ${post.read} min read</div>
@@ -41,9 +47,13 @@ const previewData = posts
     }
 
     function handleLeave(e) {
-      if (!e.target.closest) return;
+      if (!e.target.closest) {
+        return;
+      }
       const t = e.target.closest("[data-preview-slug]");
-      if (!t) return;
+      if (!t) {
+        return;
+      }
       hideT = setTimeout(() => el.setAttribute("data-visible", "false"), 80);
     }
 
@@ -53,10 +63,18 @@ const previewData = posts
         ph = 120;
       let x = r.right + 12;
       let y = r.top;
-      if (x + pw > window.innerWidth - 16) x = r.left - pw - 12;
-      if (x < 8) x = Math.min(r.left, window.innerWidth - pw - 16);
-      if (y + ph > window.innerHeight - 16) y = window.innerHeight - ph - 16;
-      if (y < 8) y = 8;
+      if (x + pw > window.innerWidth - 16) {
+        x = r.left - pw - 12;
+      }
+      if (x < 8) {
+        x = Math.min(r.left, window.innerWidth - pw - 16);
+      }
+      if (y + ph > window.innerHeight - 16) {
+        y = window.innerHeight - ph - 16;
+      }
+      if (y < 8) {
+        y = 8;
+      }
       el.style.left = x + "px";
       el.style.top = y + "px";
     }

--- a/src/components/ReadingProgress.astro
+++ b/src/components/ReadingProgress.astro
@@ -1,13 +1,17 @@
 <script>
   function initProgress() {
     const bar = document.getElementById("progress");
-    if (!bar) return;
+    if (!bar) {
+      return;
+    }
 
     bar.setAttribute("data-visible", "true");
 
     function onScroll() {
       const article = document.querySelector(".article");
-      if (!article) return;
+      if (!article) {
+        return;
+      }
       const rect = article.getBoundingClientRect();
       const total = article.scrollHeight - window.innerHeight;
       const scrolled = Math.max(0, -rect.top);

--- a/src/components/ThemeToggle.astro
+++ b/src/components/ThemeToggle.astro
@@ -1,14 +1,20 @@
 <script>
   function initThemeToggle() {
     const btn = document.querySelector("[data-theme-toggle]");
-    if (!btn) return;
+    if (!btn) {
+      return;
+    }
 
     function updateIcon() {
       const isDark = document.documentElement.getAttribute("data-theme") === "dark";
       const moon = btn!.querySelector(".icon-moon") as HTMLElement;
       const sun = btn!.querySelector(".icon-sun") as HTMLElement;
-      if (moon) moon.style.display = isDark ? "none" : "";
-      if (sun) sun.style.display = isDark ? "" : "none";
+      if (moon) {
+        moon.style.display = isDark ? "none" : "";
+      }
+      if (sun) {
+        sun.style.display = isDark ? "" : "none";
+      }
     }
 
     btn.addEventListener("click", () => {


### PR DESCRIPTION
## Summary
- Add `curly: ["error", "all"]` ESLint rule to require braces on all `if`/`else` blocks
- Fix all 23 existing violations across CommandPalette, HoverPreview, ReadingProgress, and ThemeToggle
- Add `is:inline` directive to HoverPreview script to silence Astro diagnostic hint (0 hints now)
- Document the code style convention in CLAUDE.md

## Test plan
- [x] `npm run lint` passes with no errors
- [x] `npx astro check` reports 0 errors, 0 warnings, 0 hints
- [x] Site builds and functions correctly — no behavioral changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)