### PR TITLE
fix: improve accessibility with skip link, aria labels, and nav landmarks

### DIFF
--- a/src/components/CommandPalette.tsx
+++ b/src/components/CommandPalette.tsx
@@ -170,6 +170,7 @@ export default function CommandPalette({ items }: Props) {
           <span className="palette-kbd">{isMac ? "\u2318K" : "Ctrl+K"}</span>
           <input
             ref={inputRef}
+            aria-label="Search essays, tags, pages"
             placeholder="Search essays, tags, pages…"
             autoComplete="off"
             value={q}
@@ -192,13 +193,21 @@ export default function CommandPalette({ items }: Props) {
             esc
           </button>
         </div>
-        <ul className="palette-results">
+        <div className="sr-only" aria-live="polite" role="status">
+          {q.trim()
+            ? filtered.length === 0
+              ? `No results for ${q}`
+              : `${filtered.length} result${filtered.length === 1 ? "" : "s"}`
+            : ""}
+        </div>
+        <ul className="palette-results" role="listbox">
           {filtered.length === 0 ? (
             <li className="empty">No matches for &ldquo;{q}&rdquo;</li>
           ) : (
             filtered.map((it, i) => (
               <li
                 key={it.href}
+                role="option"
                 aria-selected={i === idx}
                 onClick={() => {
                   closePalette();

--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -45,6 +45,7 @@ const fullTitle = title === META.name ? title : `${title} — ${META.name}`;
     </script>
   </head>
   <body>
+    <a href="#main" class="skip-link">Skip to content</a>
     <div class="app">
       <Masthead activeNav={activeNav} />
       <slot />

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -21,7 +21,7 @@ const dateLabel = date.toLocaleDateString("en-US", {
 ---
 
 <Base title={title} description={excerpt}>
-  <main class="page">
+  <main id="main" class="page">
     <article class="article">
       <div class="shell shell--narrow">
         <a href="/" class="article-back">&larr; Partin Thoughts</a>
@@ -48,7 +48,7 @@ const dateLabel = date.toLocaleDateString("en-US", {
 
         {
           (prev || next) && (
-            <div class="article-next">
+            <nav aria-label="Adjacent posts" class="article-next">
               {prev ? (
                 <a href={`/p/${prev.id}/`}>
                   <div class="lbl">&larr; Older</div>
@@ -65,7 +65,7 @@ const dateLabel = date.toLocaleDateString("en-US", {
               ) : (
                 <div />
               )}
-            </div>
+            </nav>
           )
         }
       </div>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -4,7 +4,7 @@ import { META } from "../types";
 ---
 
 <Base title="About" activeNav="about">
-  <main class="page">
+  <main id="main" class="page">
     <section class="about">
       <div class="shell shell--narrow">
         <div class="about-photo">EP</div>

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -28,7 +28,7 @@ const years = Object.keys(byYear)
 ---
 
 <Base title="Archive" activeNav="archive">
-  <main class="page">
+  <main id="main" class="page">
     <section class="page-head">
       <div class="shell">
         <div class="page-eyebrow">Archive</div>

--- a/src/pages/colophon.astro
+++ b/src/pages/colophon.astro
@@ -3,7 +3,7 @@ import Base from "../layouts/Base.astro";
 ---
 
 <Base title="Colophon">
-  <main class="page">
+  <main id="main" class="page">
     <section class="about">
       <div class="shell shell--narrow">
         <h1>How this site is built.</h1>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -25,7 +25,7 @@ const restEntries = rest.map((p) => ({
 ---
 
 <Base>
-  <main class="page">
+  <main id="main" class="page">
     <section class="hero">
       <div class="shell">
         <div class="hero-eyebrow">Essays &middot; Wisdom &middot; Observations</div>

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -32,7 +32,7 @@ const entries = posts.map((p) => ({
 ---
 
 <Base title={`#${tag}`} activeNav="tags">
-  <main class="page">
+  <main id="main" class="page">
     <section class="page-head">
       <div class="shell">
         <div class="page-eyebrow">Browse by tag</div>

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -25,7 +25,7 @@ const allEntries = posts.map((p) => ({
 ---
 
 <Base title="Tags" activeNav="tags">
-  <main class="page">
+  <main id="main" class="page">
     <section class="page-head">
       <div class="shell">
         <div class="page-eyebrow">Browse by tag</div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -66,6 +66,36 @@ body {
   color: var(--ink);
 }
 
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: 0;
+  z-index: 9999;
+  padding: 0.5rem 1rem;
+  background: var(--ink);
+  color: var(--bg);
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-decoration: none;
+  border-radius: 0 0 4px 0;
+}
+
+.skip-link:focus {
+  left: 0;
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 a {
   color: inherit;
   text-decoration: none;


### PR DESCRIPTION
## Summary
- Add skip-to-content link and `sr-only` utility class for keyboard users to bypass navigation
- Add `aria-label` on command palette search input and `aria-live` region to announce filtered result counts to screen readers
- Wrap prev/next post links in `<nav aria-label="Adjacent posts">` and add `id="main"` to all pages as skip-link target

## Test plan
- [x] Tab into the page — skip link should appear and jump to main content
- [ ] Open command palette and type a query — verify screen reader announces result count
- [x] Navigate to a post page — verify prev/next links are inside a `<nav>` landmark
- [x] Run `npm run build` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)