### PR TITLE
feat: add Open Graph, Twitter card, and canonical URL meta tags

### DIFF
--- a/src/layouts/Base.astro
+++ b/src/layouts/Base.astro
@@ -11,11 +11,18 @@ interface Props {
   title?: string;
   description?: string;
   activeNav?: string;
+  ogType?: "website" | "article";
 }
 
-const { title = META.name, description = META.bio, activeNav = "" } = Astro.props;
+const {
+  title = META.name,
+  description = META.bio,
+  activeNav = "",
+  ogType = "website",
+} = Astro.props;
 
 const fullTitle = title === META.name ? title : `${title} — ${META.name}`;
+const canonicalUrl = new URL(Astro.url.pathname, Astro.site).href;
 ---
 
 <!doctype html>
@@ -25,6 +32,15 @@ const fullTitle = title === META.name ? title : `${title} — ${META.name}`;
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{fullTitle}</title>
     <meta name="description" content={description} />
+    <link rel="canonical" href={canonicalUrl} />
+    <meta property="og:title" content={fullTitle} />
+    <meta property="og:description" content={description} />
+    <meta property="og:type" content={ogType} />
+    <meta property="og:url" content={canonicalUrl} />
+    <meta property="og:site_name" content={META.name} />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content={fullTitle} />
+    <meta name="twitter:description" content={description} />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
     <link rel="alternate" type="application/rss+xml" title="Partin Thoughts" href="/rss.xml" />

--- a/src/layouts/Post.astro
+++ b/src/layouts/Post.astro
@@ -20,7 +20,7 @@ const dateLabel = date.toLocaleDateString("en-US", {
 });
 ---
 
-<Base title={title} description={excerpt}>
+<Base title={title} description={excerpt} ogType="article">
   <main id="main" class="page">
     <article class="article">
       <div class="shell shell--narrow">


### PR DESCRIPTION
## Summary
- Add `<link rel="canonical">` on every page using `Astro.url.pathname` + `Astro.site`
- Add Open Graph meta tags (`og:title`, `og:description`, `og:type`, `og:url`, `og:site_name`) — posts use `og:type=article`, other pages use `website`
- Add Twitter card meta tags (`twitter:card=summary`, `twitter:title`, `twitter:description`)

## Test plan
- [x] Run `npm run build` and inspect the `<head>` of `dist/index.html` — verify OG/Twitter/canonical tags are present with correct values
- [x] Inspect a post page (e.g. `dist/p/winter-light/index.html`) — verify `og:type` is `article` and canonical URL is absolute
- [ ] Test a link preview using a social media debugger (Facebook Sharing Debugger, Twitter Card Validator, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)