### PR TITLE
feat: add custom 404 page

### DIFF
--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,0 +1,24 @@
+---
+import Base from "../layouts/Base.astro";
+---
+
+<Base title="Not found">
+  <main id="main" class="page">
+    <section class="about">
+      <div class="shell shell--narrow">
+        <h1>This page doesn&rsquo;t exist.</h1>
+        <div class="prose">
+          <p>
+            Whatever was here has moved, or never was. Either way, there&rsquo;s nothing to see at
+            this address.
+          </p>
+          <p>
+            You can head back to the <a href="/">home page</a>, browse the{" "}
+            <a href="/archive/">archive</a>, or try searching with{" "}
+            <kbd>{"\u2318"}K</kbd>.
+          </p>
+        </div>
+      </div>
+    </section>
+  </main>
+</Base>


### PR DESCRIPTION
## Summary
- Add `src/pages/404.astro` with branded layout matching the rest of the site
- Page links to home, archive, and mentions the command palette shortcut
- Builds to `/404.html`, which static hosts (Netlify, Vercel, Cloudflare Pages) serve automatically for missing routes

## Test plan
- [x] Run `npm run build` — verify `dist/404.html` is generated
- [x] Run `npm run preview` and navigate to a nonexistent path (e.g. `/doesnotexist`) — verify the custom 404 page renders
- [x] Verify links on the 404 page work (home, archive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)