### PR TITLE
fix: position hover preview above content on narrow viewports

### DIFF
--- a/src/components/HoverPreview.astro
+++ b/src/components/HoverPreview.astro
@@ -60,15 +60,23 @@ const previewData = posts
 
     function positionPreview(target) {
       const r = target.getBoundingClientRect();
-      const pw = 320,
-        ph = 120;
+      const pw = 320;
+      const ph = el.offsetHeight || 120;
       let x = r.right + 12;
       let y = r.top;
-      if (x + pw > window.innerWidth - 16) {
+      const fitsRight = x + pw <= window.innerWidth - 16;
+      const fitsLeft = r.left - pw - 12 >= 8;
+      if (fitsRight) {
+        x = r.right + 12;
+      } else if (fitsLeft) {
         x = r.left - pw - 12;
-      }
-      if (x < 8) {
-        x = Math.min(r.left, window.innerWidth - pw - 16);
+      } else {
+        x = Math.max(8, r.left + (r.width - pw) / 2);
+        x = Math.min(x, window.innerWidth - pw - 8);
+        y = r.top - ph - 8;
+        if (y < 8) {
+          y = r.bottom + 8;
+        }
       }
       if (y + ph > window.innerHeight - 16) {
         y = window.innerHeight - ph - 16;


### PR DESCRIPTION
## Summary
- When the viewport is too narrow for the preview card to fit to the right or left of the hovered link, position it above the row instead of overlapping content
- Falls back to below the row if too close to the top of the viewport
- Centers the preview horizontally over the link in the fallback position

## Test plan
- [x] At full width (~1710px) — preview should still appear to the right of the hovered link
- [x] At ~1433px — preview should appear above the hovered row, centered
- [x] Hover near the top of the page at narrow width — preview should flip below
- [x] Verify no overlap with post list content at any width

🤖 Generated with [Claude Code](https://claude.com/claude-code)