### PR TITLE
feat: support draft and archived posts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,13 @@ This is an Astro 6 static blog with React islands. It builds to pure static HTML
 
 **Content system:** Posts are Markdown files in `src/content/posts/` with typed frontmatter (title, date, tag, excerpt). The schema is defined in `src/content.config.ts` using Zod. Tags are constrained to "work", "living", "personal". Adding a post means creating a `.md` file — no other files need updating.
 
+**Draft and archived posts:** The schema also accepts two optional booleans — `draft` and `archived`. Every page loads posts through `getVisiblePosts()` in `src/utils.ts` (not `getCollection("posts")` directly), which filters them out:
+
+- `draft: true` — hidden in production builds, **visible in `npm run dev`** for local preview. Use this for work-in-progress posts you want to push to the repo without publishing.
+- `archived: true` — hidden in **both** dev and production. The markdown stays in the repo as a record but is fully off the live site (homepage, archive, tags, RSS, sitemap, command palette, hover previews, and `/p/<slug>/`).
+
+When adding new code that reads posts, always use `getVisiblePosts()` rather than calling `getCollection("posts")` directly, otherwise drafts/archived posts will leak through.
+
 **Layout hierarchy:** `Base.astro` wraps every page (head, masthead, footer, global components). It pulls default title and description from `META.name` and `META.bio` in `src/types.ts`. It also generates Open Graph, Twitter card, and canonical URL meta tags for every page. `Post.astro` extends Base for article pages, adding reading progress and prev/next navigation.
 
 **Fonts:** Self-hosted as variable woff2 files in `public/fonts/` (Inter Tight and JetBrains Mono, Latin subset). Loaded via `@font-face` declarations at the top of `global.css` — no external font services.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npx astro check      # TypeScript type checking
 
 ## Adding a post
 
-Create a markdown file in `src/content/posts/`:
+Create a markdown file in `src/content/posts/`. No other files need updating.
 
 ```markdown
 ---
@@ -31,24 +31,19 @@ title: "Your post title"
 date: 2026-04-19
 tag: work # work | living | personal
 excerpt: "A short description."
+
+# Optional flags (default false):
+draft: true # work in progress — visible only in `npm run dev`
+archived: true # retired — hidden in both dev and production
 ---
 
 Your content here.
 ```
 
-No other files need updating.
+### Optional flags
 
-### Drafts and archived posts
-
-The schema also accepts two optional booleans:
-
-```yaml
-draft: true # work in progress — visible only in `npm run dev`
-archived: true # retired — hidden in both dev and production
-```
-
-- `draft: true` keeps a post out of production builds while still letting you preview it locally with `npm run dev`. Push the file up freely; it won't appear on the live site.
-- `archived: true` hides the post in both dev and production. The markdown stays in the repo as a record but is fully off the site (homepage, archive, tags, RSS, sitemap, command palette, hover previews, and `/p/<slug>/`).
+- **`draft`** — keeps a post out of production builds while still letting you preview it locally with `npm run dev`. Push the file up freely; it won't appear on the live site.
+- **`archived`** — hides the post in both dev and production. The markdown stays in the repo as a record but is fully off the site (homepage, archive, tags, RSS, sitemap, command palette, hover previews, and `/p/<slug>/`).
 
 Filtering happens in `getVisiblePosts()` in `src/utils.ts`, which is what every page uses to load posts.
 

--- a/README.md
+++ b/README.md
@@ -40,13 +40,6 @@ archived: true # retired — hidden in both dev and production
 Your content here.
 ```
 
-### Optional flags
-
-- **`draft`** — keeps a post out of production builds while still letting you preview it locally with `npm run dev`. Push the file up freely; it won't appear on the live site.
-- **`archived`** — hides the post in both dev and production. The markdown stays in the repo as a record but is fully off the site (homepage, archive, tags, RSS, sitemap, command palette, hover previews, and `/p/<slug>/`).
-
-Filtering happens in `getVisiblePosts()` in `src/utils.ts`, which is what every page uses to load posts.
-
 ## Pages
 
 - `/` — homepage with featured post and recent feed

--- a/README.md
+++ b/README.md
@@ -38,6 +38,20 @@ Your content here.
 
 No other files need updating.
 
+### Drafts and archived posts
+
+The schema also accepts two optional booleans:
+
+```yaml
+draft: true # work in progress — visible only in `npm run dev`
+archived: true # retired — hidden in both dev and production
+```
+
+- `draft: true` keeps a post out of production builds while still letting you preview it locally with `npm run dev`. Push the file up freely; it won't appear on the live site.
+- `archived: true` hides the post in both dev and production. The markdown stays in the repo as a record but is fully off the site (homepage, archive, tags, RSS, sitemap, command palette, hover previews, and `/p/<slug>/`).
+
+Filtering happens in `getVisiblePosts()` in `src/utils.ts`, which is what every page uses to load posts.
+
 ## Pages
 
 - `/` — homepage with featured post and recent feed

--- a/src/components/CommandPaletteIsland.astro
+++ b/src/components/CommandPaletteIsland.astro
@@ -1,10 +1,9 @@
 ---
-import { getCollection } from "astro:content";
 import CommandPalette from "./CommandPalette";
 import { TAGS } from "../types";
+import { getVisiblePosts } from "../utils";
 
-const posts = await getCollection("posts");
-const sortedPosts = posts.sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+const posts = await getVisiblePosts();
 
 const items = [
   { kind: "page", title: "Home", href: "/", excerpt: "Latest essays" },
@@ -12,7 +11,7 @@ const items = [
   { kind: "page", title: "Tags", href: "/tags/", excerpt: "Filter by topic" },
   { kind: "page", title: "About", href: "/about/", excerpt: "Who writes this" },
   { kind: "page", title: "Colophon", href: "/colophon/", excerpt: "How this site is built" },
-  ...sortedPosts.map((p) => ({
+  ...posts.map((p) => ({
     kind: "essay",
     title: p.data.title,
     href: `/p/${p.id}/`,

--- a/src/components/HoverPreview.astro
+++ b/src/components/HoverPreview.astro
@@ -1,22 +1,19 @@
 ---
-import { getCollection } from "astro:content";
-import { readTime } from "../utils";
+import { getVisiblePosts, readTime } from "../utils";
 
-const posts = await getCollection("posts");
-const previewData = posts
-  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime())
-  .map((p) => ({
-    slug: p.id,
-    title: p.data.title,
-    tag: p.data.tag,
-    excerpt: p.data.excerpt,
-    dateLabel: p.data.date.toLocaleDateString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    }),
-    read: readTime(p.body),
-  }));
+const posts = await getVisiblePosts();
+const previewData = posts.map((p) => ({
+  slug: p.id,
+  title: p.data.title,
+  tag: p.data.tag,
+  excerpt: p.data.excerpt,
+  dateLabel: p.data.date.toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  }),
+  read: readTime(p.body),
+}));
 ---
 
 <script is:inline define:vars={{ previewData }}>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -10,6 +10,8 @@ const posts = defineCollection({
     tag: z.enum(["work", "living", "personal"]),
     excerpt: z.string(),
     featured: z.boolean().optional().default(false),
+    draft: z.boolean().optional().default(false),
+    archived: z.boolean().optional().default(false),
   }),
 });
 

--- a/src/pages/archive.astro
+++ b/src/pages/archive.astro
@@ -1,13 +1,10 @@
 ---
-import { getCollection } from "astro:content";
 import Base from "../layouts/Base.astro";
 import PostList from "../components/PostList.astro";
 import { META } from "../types";
-import { readTime } from "../utils";
+import { getVisiblePosts, readTime } from "../utils";
 
-const posts = (await getCollection("posts")).sort(
-  (a, b) => b.data.date.getTime() - a.data.date.getTime(),
-);
+const posts = await getVisiblePosts();
 
 const fmt = (d: Date) =>
   d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,13 +1,10 @@
 ---
-import { getCollection } from "astro:content";
 import Base from "../layouts/Base.astro";
 import PostList from "../components/PostList.astro";
 import { META } from "../types";
-import { readTime } from "../utils";
+import { getVisiblePosts, readTime } from "../utils";
 
-const posts = (await getCollection("posts")).sort(
-  (a, b) => b.data.date.getTime() - a.data.date.getTime(),
-);
+const posts = await getVisiblePosts();
 
 const featured = posts[0];
 const rest = posts.slice(1, 9);

--- a/src/pages/p/[slug].astro
+++ b/src/pages/p/[slug].astro
@@ -1,11 +1,10 @@
 ---
-import { getCollection, render } from "astro:content";
+import { render } from "astro:content";
 import PostLayout from "../../layouts/Post.astro";
+import { getVisiblePosts } from "../../utils";
 
 export async function getStaticPaths() {
-  const posts = (await getCollection("posts")).sort(
-    (a, b) => b.data.date.getTime() - a.data.date.getTime(),
-  );
+  const posts = await getVisiblePosts();
 
   return posts.map((post, i) => {
     const prev = posts[i + 1] ?? null;

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,12 +1,10 @@
 import rss from "@astrojs/rss";
-import { getCollection } from "astro:content";
 import type { APIContext } from "astro";
 import { META } from "../types";
+import { getVisiblePosts } from "../utils";
 
 export async function GET(context: APIContext) {
-  const posts = (await getCollection("posts")).sort(
-    (a, b) => b.data.date.getTime() - a.data.date.getTime(),
-  );
+  const posts = await getVisiblePosts();
 
   return rss({
     title: META.name,

--- a/src/pages/tags/[tag].astro
+++ b/src/pages/tags/[tag].astro
@@ -1,9 +1,8 @@
 ---
-import { getCollection } from "astro:content";
 import Base from "../../layouts/Base.astro";
 import PostList from "../../components/PostList.astro";
 import { TAGS, type Tag } from "../../types";
-import { readTime } from "../../utils";
+import { getVisiblePosts, readTime } from "../../utils";
 
 export function getStaticPaths() {
   return TAGS.map((tag) => ({ params: { tag } }));
@@ -11,11 +10,9 @@ export function getStaticPaths() {
 
 const { tag } = Astro.params as { tag: Tag };
 
-const posts = (await getCollection("posts"))
-  .filter((p) => p.data.tag === tag)
-  .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+const allPosts = await getVisiblePosts();
+const posts = allPosts.filter((p) => p.data.tag === tag);
 
-const allPosts = await getCollection("posts");
 const counts: Record<string, number> = { all: allPosts.length };
 for (const p of allPosts) {
   counts[p.data.tag] = (counts[p.data.tag] || 0) + 1;

--- a/src/pages/tags/index.astro
+++ b/src/pages/tags/index.astro
@@ -1,13 +1,10 @@
 ---
-import { getCollection } from "astro:content";
 import Base from "../../layouts/Base.astro";
 import PostList from "../../components/PostList.astro";
 import { TAGS } from "../../types";
-import { readTime } from "../../utils";
+import { getVisiblePosts, readTime } from "../../utils";
 
-const posts = (await getCollection("posts")).sort(
-  (a, b) => b.data.date.getTime() - a.data.date.getTime(),
-);
+const posts = await getVisiblePosts();
 
 const fmt = (d: Date) =>
   d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,54 @@
+import { getCollection, type CollectionEntry } from "astro:content";
+
+/**
+ * Estimates reading time in minutes based on a 250-words-per-minute pace.
+ * Returns at least 1 minute, even for empty or very short bodies.
+ *
+ * @param body - The raw markdown body of a post.
+ * @returns Whole minutes, rounded up.
+ */
 export function readTime(body: string | undefined): number {
   return Math.max(1, Math.ceil((body?.split(/\s+/).length ?? 0) / 250));
 }
 
+/**
+ * Loads posts from the `posts` collection, filters out drafts and archived
+ * posts, and returns them sorted newest-first by date.
+ *
+ * Filtering rules:
+ * - `archived: true` posts are excluded in both dev and production.
+ * - `draft: true` posts are excluded only in production builds, so they
+ *   remain previewable via `npm run dev`.
+ *
+ * Every page that surfaces posts (homepage, archive, tags, RSS, sitemap,
+ * command palette, hover preview, `/p/[slug]`) should call this rather than
+ * `getCollection("posts")` directly to keep drafts and archived posts off
+ * the live site.
+ *
+ * @returns Visible posts, sorted by `data.date` descending.
+ */
+export async function getVisiblePosts(): Promise<CollectionEntry<"posts">[]> {
+  const posts = await getCollection("posts");
+  return posts
+    .filter((p) => {
+      if (p.data.archived) {
+        return false;
+      }
+      if (p.data.draft && import.meta.env.PROD) {
+        return false;
+      }
+      return true;
+    })
+    .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
+}
+
+/**
+ * Computes the user's whole-year age from a birth date, accounting for
+ * whether the birthday has occurred yet this calendar year.
+ *
+ * @param birthDate - The birth date to measure from.
+ * @returns Age in completed years.
+ */
 export function age(birthDate: Date): number {
   const today = new Date();
   let years = today.getFullYear() - birthDate.getFullYear();


### PR DESCRIPTION
## Summary
- Adds optional `draft` and `archived` booleans to the post frontmatter schema. Drafts are hidden in production but visible in `npm run dev`; archived posts are hidden in both, so the markdown stays in the repo while the post is fully off the live site (homepage, archive, tags, RSS, sitemap, command palette, hover preview, and `/p/<slug>/`).
- Centralizes the filtering in a new `getVisiblePosts()` helper in `src/utils.ts`. Every page that previously called `getCollection("posts")` now goes through it, and the helper also returns posts pre-sorted newest-first so per-call-site sorts are gone.
- Documents the new workflow and the `getVisiblePosts()` convention in `CLAUDE.md`, and adds JSDoc to the utilities.

## Test plan
- [x] `npm run dev` — confirm a post with `draft: true` shows up locally
- [x] `npm run build` — confirm the same draft post is absent from `dist/` (no `/p/<slug>/`, not in homepage/archive/tags/RSS/sitemap)
- [x] Mark a post `archived: true` and confirm it disappears in both dev and production builds
- [x] Existing posts (no flags) render exactly as before, in the same order

🤖 Generated with [Claude Code](https://claude.com/claude-code)