### PR TITLE
chore: remove unused featured post flag

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -9,7 +9,6 @@ const posts = defineCollection({
     date: z.coerce.date(),
     tag: z.enum(["work", "living", "personal"]),
     excerpt: z.string(),
-    featured: z.boolean().optional().default(false),
     draft: z.boolean().optional().default(false),
     archived: z.boolean().optional().default(false),
   }),

--- a/src/content/posts/on-leaving-the-open-plan.md
+++ b/src/content/posts/on-leaving-the-open-plan.md
@@ -3,7 +3,6 @@ title: "On leaving the open plan"
 date: 2026-03-24
 tag: work
 excerpt: "After four years of hotdesks, I moved into a room with a door. The first week was disorienting in a way I didn't expect."
-featured: true
 ---
 
 For most of my career I worked in spaces where being seen was part of the job. Not in a performative sense — just ambiently. You could glance up and clock who was deep in something, who was stuck, who was free for a quick question. Collaboration by proximity.


### PR DESCRIPTION
## Summary
- Drop the `featured` field from the post Zod schema in `src/content.config.ts` and from the only post that set it (`on-leaving-the-open-plan.md`)
- The flag was never read — `src/pages/index.astro` already picks the homepage feature slot as `posts[0]`, which is the newest visible post via `getVisiblePosts()`
- Closes #28

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npx astro check`
- [x] `npm run build`
- [x] Confirm homepage feature card still renders the latest post in preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)