### PR TITLE
refactor: derive Tag type from TAGS constant

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,13 +1,14 @@
 import { defineCollection } from "astro:content";
 import { glob } from "astro/loaders";
 import { z } from "astro/zod";
+import { TAGS } from "./types";
 
 const posts = defineCollection({
   loader: glob({ pattern: "**/*.md", base: "./src/content/posts" }),
   schema: z.object({
     title: z.string(),
     date: z.coerce.date(),
-    tag: z.enum(["work", "living", "personal"]),
+    tag: z.enum(TAGS),
     excerpt: z.string(),
     draft: z.boolean().optional().default(false),
     archived: z.boolean().optional().default(false),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,6 @@
-export type Tag = "work" | "living" | "personal";
+export const TAGS = ["work", "living", "personal"] as const;
 
-export const TAGS: Tag[] = ["work", "living", "personal"];
+export type Tag = (typeof TAGS)[number];
 
 export const META = {
   name: "Partin Thoughts",


### PR DESCRIPTION
## Summary
- Make `TAGS` the single source of truth — derive the `Tag` type from it and use it directly in the Zod schema for `content.config.ts`, replacing the duplicated string-literal enum.

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npx astro check`
- [x] `npm run build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)