### PR TITLE
feat: add "Wise but wrong" post

### DIFF
--- a/src/content/posts/wise-but-wrong.md
+++ b/src/content/posts/wise-but-wrong.md
@@ -1,0 +1,36 @@
+---
+title: "Wise but wrong"
+date: "2026-05-04"
+tag: living
+excerpt: "What is wise isn't always what is right"
+---
+
+When I'm sitting in front of a hard decision, I feel the pull to be the one with the answer — the decision-maker, the problem-solver. But what if I've been coming to my decisions and solutions incorrectly?
+
+## Pursuing what is wise
+
+In 2 Chronicles 1, we see God grant King Solomon wisdom per his request. King Solomon showcases his extraordinary wisdom in 1 Kings 3:16-28, when two women each claim to be a newborn's mother. He calls for a sword and orders the child cut in two — knowing the real mother will surrender her claim before letting the child die. A wise choice.
+
+Later in 2 Chronicles 1, we read about the great wealth Solomon accumulates, including gold, silver, and horses from Egypt for his chariots and horsemen. King David, his father, had warred greatly to establish peace in Israel. Solomon, his son, worked to maintain an image of power. A wise choice.
+
+## The consequences of wisdom
+
+Solomon's action, despite being wise, was also wrong.
+
+When he amasses wealth and brings horses from Egypt, he is in direct contradiction of Deuteronomy 17:16-17:
+
+> Only he must not multiply horses for himself, or cause the people to return to Egypt in order to multiply horses, since the Lord has said to you, ‘You shall never return that way again.’ And he shall not multiply wives for himself, lest his heart turn away; nor shall he greatly multiply for himself silver and gold.
+
+These actions of Solomon also led to him turning away from the Lord.
+
+## Obedience
+
+After reading through these passages of scripture, I'm left shaken. Shaken by the fact that my wise decisions can be the wrong ones.
+
+I'm left thinking of past decisions that have brought me here. How many times have I failed?
+
+As I strive to become a man after God's own heart, I look back and recognize a time I chose a "wise" option. I thought I was sparing someone's feelings, but I realize now I was protecting myself. The aftermath left me broken and alone.
+
+Looking up through the tears I realized God still stood with me in my mistakes, asking me to obey His will. I find the most comfort when I follow Him. A _truly_ wise choice.
+
+What is wise, is not what is always right, but what is obedient, is always wise.


### PR DESCRIPTION
## Summary
- feat: add "Wise but wrong" post — a reflection on Solomon, decision-making, and the gap between what is wise and what is obedient

## Test plan
- [x] `npm run lint`
- [x] `npm run format:check`
- [x] `npx astro check`
- [x] `npm run build`
- [x] Verify the post renders at `/p/wise-but-wrong/` and appears on the homepage and `/tags/living/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)