### PR TITLE
fix: point site URL at ethan.partin.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Partin Thoughts
 
+Live at **[ethan.partin.io](https://ethan.partin.io)**.
+
 A place to share my parting thoughts. A personal blog built with [Astro](https://astro.build) — personal essays, borrowed wisdom, and observations from the ordinary.
 
 ## Getting started

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,6 @@ import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
 
 export default defineConfig({
-  site: "https://thoughts.partin.io",
+  site: "https://ethan.partin.io",
   integrations: [react(), sitemap()],
 });


### PR DESCRIPTION
## Summary

- **fix:** point the Astro `site` config at `https://ethan.partin.io` (was the unused `thoughts.partin.io`). That value drives all absolute URLs, so this corrects the RSS feed links, sitemap, and canonical/OG/Twitter tags in one change.
- **docs:** add a live site link to the README.

## Test plan

- [x] `npm run build` succeeds; `dist/rss.xml`, `dist/sitemap-0.xml`, and `dist/index.html` canonical/`og:url` all emit `https://ethan.partin.io/...`
- [x] No stale `thoughts.partin.io` references remain in `dist/`
- [x] Sitemap index points to `https://ethan.partin.io/sitemap-0.xml`
- [ ] After merge: confirm the mirror Action deploys and the live RSS/sitemap reflect the new domain

🤖 Generated with [Claude Code](https://claude.com/claude-code)