### PR TITLE
feat: add anchor links to post headings

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -2,8 +2,28 @@
 import { defineConfig } from "astro/config";
 import react from "@astrojs/react";
 import sitemap from "@astrojs/sitemap";
+import { unified } from "@astrojs/markdown-remark";
+import rehypeSlug from "rehype-slug";
+import rehypeAutolinkHeadings from "rehype-autolink-headings";
 
 export default defineConfig({
   site: "https://ethan.partin.io",
   integrations: [react(), sitemap()],
+  markdown: {
+    // Give every heading an id (rehypeSlug), then make the whole heading a
+    // self-link to that id (rehypeAutolinkHeadings, behavior: "wrap"). Order
+    // matters: slug must run first so the ids exist to link to.
+    processor: unified({
+      rehypePlugins: [
+        rehypeSlug,
+        [
+          rehypeAutolinkHeadings,
+          {
+            behavior: "wrap",
+            properties: { className: "heading-anchor" },
+          },
+        ],
+      ],
+    }),
+  },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,8 @@
         "astro": "^6.4.6",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "rehype-autolink-headings": "^7.1.0",
+        "rehype-slug": "^6.0.0",
         "typescript": "^5.9.3"
       },
       "devDependencies": {
@@ -5022,6 +5024,19 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/hast-util-heading-rank": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-heading-rank/-/hast-util-heading-rank-3.0.0.tgz",
+      "integrity": "sha512-EJKb8oMUXVHcWZTDepnr+WNbfnXKFNf9duMesmr4S8SXTJBJ9M4Yok08pu9vxdJwdlGRhVumk9mEhkEvKGifwA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-is-element": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/hast-util-is-element/-/hast-util-is-element-3.0.0.tgz",
@@ -5109,6 +5124,19 @@
         "space-separated-tokens": "^2.0.0",
         "web-namespaces": "^2.0.0",
         "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-to-string": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-to-string/-/hast-util-to-string-3.0.1.tgz",
+      "integrity": "sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7154,6 +7182,24 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/rehype-autolink-headings": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/rehype-autolink-headings/-/rehype-autolink-headings-7.1.0.tgz",
+      "integrity": "sha512-rItO/pSdvnvsP4QRB1pmPiNHUskikqtPojZKJPPPAVx9Hj8i8TwMBhofrrAYRhYOOBZH9tgmG5lPqDLuIWPWmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-is-element": "^3.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/rehype-parse": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/rehype-parse/-/rehype-parse-9.0.1.tgz",
@@ -7178,6 +7224,23 @@
         "@types/hast": "^3.0.0",
         "hast-util-raw": "^9.0.0",
         "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/rehype-slug": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/rehype-slug/-/rehype-slug-6.0.0.tgz",
+      "integrity": "sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "github-slugger": "^2.0.0",
+        "hast-util-heading-rank": "^3.0.0",
+        "hast-util-to-string": "^3.0.0",
+        "unist-util-visit": "^5.0.0"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,8 @@
     "astro": "^6.4.6",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "rehype-autolink-headings": "^7.1.0",
+    "rehype-slug": "^6.0.0",
     "typescript": "^5.9.3"
   },
   "devDependencies": {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -67,6 +67,7 @@ body {
 }
 html {
   background: var(--bg);
+  scroll-behavior: smooth;
 }
 
 body {
@@ -569,6 +570,7 @@ kbd {
   width: 1.6em;
   margin-left: -1.6em;
   vertical-align: 4px;
+  transition: color 180ms var(--ease);
 }
 .prose a {
   color: var(--accent-ink);
@@ -577,6 +579,22 @@ kbd {
 }
 .prose a:hover {
   border-bottom-color: var(--accent-ink);
+}
+/* Heading self-links (rehype-autolink-headings, behavior: "wrap"):
+   render as plain headings, hint interactivity on hover. */
+.prose a.heading-anchor {
+  color: inherit;
+  border-bottom: none;
+  transition: color 180ms var(--ease);
+}
+.prose a.heading-anchor:hover {
+  color: var(--accent-ink);
+}
+.prose h2:hover::before {
+  color: var(--accent-ink);
+}
+.prose :is(h1, h2, h3, h4) {
+  scroll-margin-top: 1.5rem;
 }
 .prose blockquote {
   margin: 1.6em 0;
@@ -1155,5 +1173,8 @@ kbd {
   * {
     animation-duration: 0.01ms !important;
     transition-duration: 0.01ms !important;
+  }
+  html {
+    scroll-behavior: auto;
   }
 }


### PR DESCRIPTION
## Summary

- **feat:** post headings are now self-links — `rehype-slug` adds an `id` to each heading and `rehype-autolink-headings` (`behavior: "wrap"`) makes the heading text a link to it, so readers can deep-link to any section. Clicking smooth-scrolls to the heading and sets a shareable `#fragment` URL.

## Details

- Anchors inherit the heading color with no underline, so headings look identical by default; on hover the text and the `§` marker tint to the accent. Applies to `##`/`###`; the post `h1` title is untouched.
- Smooth scroll is enabled on `html`, disabled under `prefers-reduced-motion: reduce` (instant jump), plus `scroll-margin-top` so a jumped-to heading isn't flush against the top.
- Uses Astro 6.4's supported `markdown.processor: unified({ ... })` API (not the deprecated `markdown.rehypePlugins`), so no build-time deprecation warning.

## Test plan

- [x] `npm run build` succeeds with no deprecation warnings
- [x] Every `##`/`###` in a post renders as `<h2 id=".."><a class="heading-anchor" href="#..">..</a></h2>`
- [x] `lint`, `format:check`, and `astro check` all clean
- [ ] After merge: click a heading on the live site → smooth-scrolls and the URL gains the `#section` fragment

🤖 Generated with [Claude Code](https://claude.com/claude-code)